### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_script:
   - npm install -g --production coveralls codecov
 script:
   - npm run cover
+  - npm run lint
+  - npm run docs
 after_script:
   - codecov
   - cat ./build/coverage/lcov.info | coveralls

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "precover": "rollup -c tests/rollup.config.js",
     "posttest": "npm run prepare && markdown-doctest",
     "start": "node bin/npm-template-sync-github-hook",
-    "docs": "jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md",
+    "docs": "documentation readme {{module}} --section=API",
     "semantic-release": "semantic-release",
-    "prepare": "rollup -c && chmod +x bin/npm-template-sync-github-hook"
+    "prepare": "rollup -c && chmod +x bin/npm-template-sync-github-hook",
+    "lint": "documentation lint {{module}}"
   },
   "bin": {
     "npm-template-sync-github-hook": "bin/npm-template-sync-github-hook"
@@ -31,19 +32,17 @@
   },
   "devDependencies": {
     "ava": "^0.24.0",
-    "jsdoc-babel": "^0.3.0",
-    "jsdoc-to-markdown": "^3.0.2",
     "markdown-doctest": "^0.9.1",
     "mock-repository-provider": "^1.0.0",
     "nyc": "^11.4.1",
-    "rollup": "^0.52.3",
+    "rollup": "^0.53.0",
     "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-multi-entry": "^2.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "semantic-release": "^11.0.2",
     "xo": "^0.19.0",
-    "babel-preset-env": "^1.6.1"
+    "documentation": "^5.3.5"
   },
   "release": {},
   "keywords": [


### PR DESCRIPTION
package.json
---
- chore(devDependencies): remove jsdoc-babel@^0.3.0
- chore(devDependencies): remove jsdoc-to-markdown@^3.0.2
- chore(devDependencies): add documentation@^5.3.5 from template
- chore(devDependencies): update rollup@^0.53.0 from template
- chore(scripts): update prepare@rollup -c from template
- chore(scripts): update docs@documentation readme {{module}} --section=API from template
- chore(scripts): add lint@documentation lint {{module}} from template

.travis.yml
---
- chore(travis): merge from template .travis.yml
